### PR TITLE
Add support for hytale permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.4
+
+* Properly configured permission, now the admin screen and the nav bar will hide the entries if the player doesn't have the permission, closes #2
+
 # 1.0.3
 
 * Add support for the new Auth system

--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -1,0 +1,42 @@
+# AdminUI Permissions
+
+This document lists all the permissions used by the AdminUI plugin.
+
+## Core Permissions
+
+| Permission | Description |
+|------------|-------------|
+| `AdminUI.admin` | Master permission. Grants access to all AdminUI features. |
+
+## Module Permissions
+
+These permissions grant access to specific modules within the AdminUI. They control visibility in the navigation bar and the ability to open the respective GUIs.
+
+Granting the root permission (e.g., `AdminUI.whitelist`) grants access to all actions within that module.
+
+| Permission                | Description                                               |
+|---------------------------|-----------------------------------------------------------|
+| `AdminUI.ban.open`        | Access to the Ban management GUI.                         |
+| `AdminUI.mute.open`       | Access to the Mute management GUI.                        |
+| `AdminUI.player.open`     | Access to the Player management GUI.                      |
+| `AdminUI.stats.open`      | Access to the Server Stats GUI.                           |
+| `AdminUI.ui.open`         | Grants access to the main `/admin` command and index GUI. |
+| `AdminUI.warp.open`       | Access to the Warps management GUI.                       |
+| `AdminUI.whitelist.open`  | Access to the Whitelist management GUI.                   |
+| `AdminUI.adminstick.open` | Access to the Admin Stick configuration GUI.              |
+| `AdminUI.adminstick.use`  | Access to the Admin Stick usage.                          |
+| `AdminUI.backup.open`     | Access to the Server Backups management GUI.              |
+
+## Permission Roots
+
+You can also use these root permissions to grant full access to a specific module:
+
+- `AdminUI.ui`
+- `AdminUI.ban`
+- `AdminUI.mute`
+- `AdminUI.player`
+- `AdminUI.stats`
+- `AdminUI.warp`
+- `AdminUI.whitelist`
+- `AdminUI.adminstick`
+- `AdminUI.backup`

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ repositories {
 dependencies {
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
-    implementation(files(System.getProperty("user.home") + "/AppData/Roaming/Hytale/install/pre-release/package/game/$game_build/Server/HytaleServer.jar"))
+    implementation(files(System.getProperty("user.home") + "/AppData/Roaming/Hytale/install/release/package/game/$game_build/Server/HytaleServer.jar"))
 }
 
 test {

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,4 +7,4 @@ game_build=latest
 
 
 hytaleHome=C:/Users/buuz1/AppData/Roaming/Hytale/install
-patchline=pre-release
+patchline=release

--- a/src/main/java/com/buuz135/adminui/AdminUI.java
+++ b/src/main/java/com/buuz135/adminui/AdminUI.java
@@ -80,14 +80,14 @@ public class AdminUI extends JavaPlugin {
         this.backupConfiguration.syncLoad();
 
         //ADMIN UI PAGES
-        AdminUIIndexRegistry.getInstance().register(new AdminUIIndexRegistry.Entry("whitelist", "Whitelists", WhitelistGui::new, true, "wl", "whitelists"));
-        AdminUIIndexRegistry.getInstance().register(new AdminUIIndexRegistry.Entry("mute", "Mutes", MuteGui::new, true, "m", "mute"));
-        AdminUIIndexRegistry.getInstance().register(new AdminUIIndexRegistry.Entry("ban", "Bans", BanGui::new, true, "b", "bans"));
-        AdminUIIndexRegistry.getInstance().register(new AdminUIIndexRegistry.Entry("player", "Players", PlayerGui::new, true, "p", "players"));
-        AdminUIIndexRegistry.getInstance().register(new AdminUIIndexRegistry.Entry("warps", "Warps", WarpGui::new, true, "w", "warps"));
-        AdminUIIndexRegistry.getInstance().register(new AdminUIIndexRegistry.Entry("admin-stick", "Admin Stick", AdminStickGui::new, true));
-        AdminUIIndexRegistry.getInstance().register(new AdminUIIndexRegistry.Entry("backup", "Server Backups", BackupGui::new, true, "bk", "backup"));
-        AdminUIIndexRegistry.getInstance().register(new AdminUIIndexRegistry.Entry("server", "Server Stats", StatsGui::new, true, "st", "stats"));
+        AdminUIIndexRegistry.getInstance().register(new AdminUIIndexRegistry.Entry("whitelist", "Whitelists", PermissionList.WHITELIST_OPEN_UI, WhitelistGui::new, true, "wl", "whitelists"));
+        AdminUIIndexRegistry.getInstance().register(new AdminUIIndexRegistry.Entry("mute", "Mutes", PermissionList.MUTE_OPEN_UI,MuteGui::new, true, "m", "mute"));
+        AdminUIIndexRegistry.getInstance().register(new AdminUIIndexRegistry.Entry("ban", "Bans", PermissionList.BAN_OPEN_UI, BanGui::new, true, "b", "bans"));
+        AdminUIIndexRegistry.getInstance().register(new AdminUIIndexRegistry.Entry("player", "Players", PermissionList.PLAYER_OPEN_UI, PlayerGui::new, true, "p", "players"));
+        AdminUIIndexRegistry.getInstance().register(new AdminUIIndexRegistry.Entry("warps", "Warps", PermissionList.WARP_OPEN_UI, WarpGui::new, true, "w", "warps"));
+        AdminUIIndexRegistry.getInstance().register(new AdminUIIndexRegistry.Entry("admin-stick", "Admin Stick", PermissionList.ADMIN_STICK_OPEN_UI, AdminStickGui::new, true));
+        AdminUIIndexRegistry.getInstance().register(new AdminUIIndexRegistry.Entry("backup", "Server Backups", PermissionList.BACKUP_OPEN_UI, BackupGui::new, true, "bk", "backup"));
+        AdminUIIndexRegistry.getInstance().register(new AdminUIIndexRegistry.Entry("server", "Server Stats", PermissionList.STATS_OPEN_UI, StatsGui::new, true, "st", "stats"));
 
         //PROVIDERS
         this.whitelistProvider = ReflectionUtil.getPublic(HytaleWhitelistProvider.class, AccessControlModule.get(), "whitelistProvider");

--- a/src/main/java/com/buuz135/adminui/AdminUIIndexRegistry.java
+++ b/src/main/java/com/buuz135/adminui/AdminUIIndexRegistry.java
@@ -2,6 +2,7 @@ package com.buuz135.adminui;
 
 import com.buuz135.adminui.command.AdminCommand;
 import com.buuz135.adminui.command.AdminShortcutCommand;
+import com.buuz135.adminui.util.PermissionList;
 import com.hypixel.hytale.server.core.entity.entities.player.pages.InteractiveCustomUIPage;
 import com.hypixel.hytale.server.core.universe.PlayerRef;
 
@@ -45,6 +46,6 @@ public class AdminUIIndexRegistry {
         return command;
     }
 
-    public record Entry(String id, String displayName, Function<PlayerRef, ? extends InteractiveCustomUIPage<?>> guiSupplier, boolean showsInNavBar, String... commandShortcut) {
+    public record Entry(String id, String displayName, PermissionList permission, Function<PlayerRef, ? extends InteractiveCustomUIPage<?>> guiSupplier, boolean showsInNavBar, String... commandShortcut) {
     }
 }

--- a/src/main/java/com/buuz135/adminui/command/AdminCommand.java
+++ b/src/main/java/com/buuz135/adminui/command/AdminCommand.java
@@ -2,6 +2,7 @@ package com.buuz135.adminui.command;
 
 
 import com.buuz135.adminui.gui.AdminIndexGui;
+import com.buuz135.adminui.util.PermissionList;
 import com.hypixel.hytale.component.Ref;
 import com.hypixel.hytale.component.Store;
 import com.hypixel.hytale.protocol.GameMode;
@@ -23,7 +24,7 @@ public class AdminCommand extends AbstractAsyncCommand {
 
     public AdminCommand() {
         super("admin", "Shows all the admin GUIs" );
-        this.setPermissionGroups("OP");
+        this.requirePermission(PermissionList.OPEN_UI.getPermission());
     }
 
     @NonNullDecl

--- a/src/main/java/com/buuz135/adminui/command/AdminShortcutCommand.java
+++ b/src/main/java/com/buuz135/adminui/command/AdminShortcutCommand.java
@@ -2,6 +2,7 @@ package com.buuz135.adminui.command;
 
 
 import com.buuz135.adminui.AdminUIIndexRegistry;
+import com.buuz135.adminui.util.PermissionList;
 import com.hypixel.hytale.component.Ref;
 import com.hypixel.hytale.component.Store;
 import com.hypixel.hytale.protocol.GameMode;
@@ -31,7 +32,7 @@ public class AdminShortcutCommand extends AbstractAsyncCommand {
                 this.addAliases(entry.commandShortcut()[i]);
             }
         }
-        this.setPermissionGroups("OP");
+        this.requirePermission(entry.permission().getPermission());
     }
 
     @NonNullDecl

--- a/src/main/java/com/buuz135/adminui/gui/AdminIndexGui.java
+++ b/src/main/java/com/buuz135/adminui/gui/AdminIndexGui.java
@@ -2,6 +2,7 @@ package com.buuz135.adminui.gui;
 
 
 import com.buuz135.adminui.AdminUIIndexRegistry;
+import com.buuz135.adminui.util.PermissionList;
 import com.hypixel.hytale.codec.Codec;
 import com.hypixel.hytale.codec.KeyedCodec;
 import com.hypixel.hytale.codec.builder.BuilderCodec;
@@ -18,6 +19,8 @@ import com.hypixel.hytale.server.core.universe.PlayerRef;
 import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
 
 import javax.annotation.Nonnull;
+import java.util.HashMap;
+import java.util.Map;
 
 public class AdminIndexGui extends InteractiveCustomUIPage<AdminIndexGui.IndexGuiData> {
 
@@ -33,7 +36,9 @@ public class AdminIndexGui extends InteractiveCustomUIPage<AdminIndexGui.IndexGu
         NavBarHelper.setupBar(ref, uiCommandBuilder, uiEventBuilder, store);
         int rowIndex = 0;
         int cardsInCurrentRow = 0;
+        var player = store.getComponent(ref, Player.getComponentType());
         for (AdminUIIndexRegistry.Entry entry : AdminUIIndexRegistry.getInstance().getEntries()) {
+            if(!entry.permission().hasPermission(player)) {continue;}
             if (cardsInCurrentRow == 0) {
                 uiCommandBuilder.appendInline("#IndexCards", "Group { LayoutMode: Left; Anchor: (Bottom: 0); }");
             }

--- a/src/main/java/com/buuz135/adminui/gui/AdminStickGui.java
+++ b/src/main/java/com/buuz135/adminui/gui/AdminStickGui.java
@@ -43,7 +43,8 @@ public class AdminStickGui extends InteractiveCustomUIPage<AdminStickGui.SearchG
         uiEventBuilder.addEventBinding(CustomUIEventBindingType.Activating, "#BackButton", EventData.of("Button", "BackButton"), false);
         var playerRef = store.getComponent(ref, PlayerRef.getComponentType());
         var config = AdminUI.getInstance().getAdminStickCustomConfig().getPlayer(playerRef.getUuid());
-        var entries = AdminUIIndexRegistry.getInstance().getEntries().stream().map(entry -> new DropdownEntryInfo(LocalizableString.fromString(entry.displayName()), entry.id())).collect(Collectors.toList());
+        var player = store.getComponent(ref, Player.getComponentType());
+        var entries = AdminUIIndexRegistry.getInstance().getEntries().stream().filter(e -> e.permission().hasPermission(player)).map(entry -> new DropdownEntryInfo(LocalizableString.fromString(entry.displayName()), entry.id())).collect(Collectors.toList());
         entries.add(0, new DropdownEntryInfo(LocalizableString.fromString("None"), ""));
 
         uiCommandBuilder.set("#Ability1Dropdown.Entries", entries);

--- a/src/main/java/com/buuz135/adminui/gui/NavBarHelper.java
+++ b/src/main/java/com/buuz135/adminui/gui/NavBarHelper.java
@@ -1,6 +1,7 @@
 package com.buuz135.adminui.gui;
 
 import com.buuz135.adminui.AdminUIIndexRegistry;
+import com.buuz135.adminui.util.PermissionList;
 import com.hypixel.hytale.component.Ref;
 import com.hypixel.hytale.component.Store;
 import com.hypixel.hytale.protocol.packets.interface_.CustomUIEventBindingType;
@@ -12,13 +13,17 @@ import com.hypixel.hytale.server.core.universe.PlayerRef;
 import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
 
 import javax.annotation.Nonnull;
+import java.util.HashMap;
+import java.util.Map;
 
 public class NavBarHelper {
 
     public static void setupBar(@Nonnull Ref<EntityStore> ref, @Nonnull UICommandBuilder uiCommandBuilder, @Nonnull UIEventBuilder uiEventBuilder, @Nonnull Store<EntityStore> store){
+        var player = store.getComponent(ref, Player.getComponentType());
         int index = 0;
         uiCommandBuilder.appendInline("#AdminUITopNavigationBar #NavBarButtons", "Group #NavCards { LayoutMode: Left; }");
         for (AdminUIIndexRegistry.Entry entry : AdminUIIndexRegistry.getInstance().getEntries()) {
+            if(!entry.permission().hasPermission(player)) {continue;}
             uiCommandBuilder.append("#NavCards", "Pages/Nav/Buuz135_AdminUI_TopNavigationBarButton.ui");
             uiCommandBuilder.set("#NavBarButtons #NavCards[" + index + "] #NavActionButton.Text", entry.displayName());
             uiEventBuilder.addEventBinding(CustomUIEventBindingType.Activating, "#NavBarButtons #NavCards[" + index + "] #NavActionButton", EventData.of("NavBar", entry.id()));

--- a/src/main/java/com/buuz135/adminui/interaction/AdminStickInteraction.java
+++ b/src/main/java/com/buuz135/adminui/interaction/AdminStickInteraction.java
@@ -6,6 +6,7 @@ import com.buuz135.adminui.AdminUIIndexRegistry;
 import com.buuz135.adminui.gui.AdminIndexGui;
 import com.buuz135.adminui.gui.PlayerGui;
 import com.buuz135.adminui.gui.StatsGui;
+import com.buuz135.adminui.util.PermissionList;
 import com.hypixel.hytale.codec.builder.BuilderCodec;
 import com.hypixel.hytale.component.CommandBuffer;
 import com.hypixel.hytale.component.Ref;
@@ -15,11 +16,7 @@ import com.hypixel.hytale.protocol.InteractionType;
 import com.hypixel.hytale.protocol.packets.interface_.CustomPageLifetime;
 import com.hypixel.hytale.server.core.entity.InteractionContext;
 import com.hypixel.hytale.server.core.entity.entities.Player;
-import com.hypixel.hytale.server.core.inventory.ItemStack;
-import com.hypixel.hytale.server.core.modules.interaction.interaction.CooldownHandler;
 import com.hypixel.hytale.server.core.modules.interaction.interaction.config.SimpleInteraction;
-import com.hypixel.hytale.server.core.modules.interaction.interaction.config.client.SimpleBlockInteraction;
-import com.hypixel.hytale.server.core.permissions.PermissionsModule;
 import com.hypixel.hytale.server.core.universe.PlayerRef;
 import com.hypixel.hytale.server.core.universe.world.World;
 import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
@@ -33,11 +30,10 @@ public class AdminStickInteraction extends SimpleInteraction {
     @Override
     public void handle(@NonNullDecl Ref<EntityStore> ref, boolean firstRun, float time, @NonNullDecl InteractionType type, @NonNullDecl InteractionContext interactionContext) {
         super.handle(ref, firstRun, time, type, interactionContext);
-        var perms = PermissionsModule.get();
         var store = ref.getStore();
         var player = ref.getStore().getComponent(ref, Player.getComponentType());
         PlayerRef playerRefComponent = store.getComponent(ref, PlayerRef.getComponentType());
-        if (!perms.getGroupsForUser(playerRefComponent.getUuid()).contains("OP")) return;
+        if (!PermissionList.ADMIN_STICK_USE.hasPermission(player)) return;
         var config = AdminUI.getInstance().getAdminStickCustomConfig();
         var id = "";
         if (type == InteractionType.Ability1) id = config.getPlayer(playerRefComponent.getUuid()).ability1();
@@ -48,11 +44,13 @@ public class AdminStickInteraction extends SimpleInteraction {
         if (type == InteractionType.Pick) id = config.getPlayer(playerRefComponent.getUuid()).pick();
 
         var entry = AdminUIIndexRegistry.getInstance().getEntry(id);
-        if (id.isEmpty() || entry == null){
+        if (entry == null || id.isEmpty() || !entry.permission().hasPermission(player)) {
             player.getPageManager().openCustomPage(ref, store, new AdminIndexGui(playerRefComponent, CustomPageLifetime.CanDismiss));
             return;
         }
-        player.getPageManager().openCustomPage(ref, store, entry.guiSupplier().apply(playerRefComponent));
+        if (entry.permission().hasPermission(player)) {
+            player.getPageManager().openCustomPage(ref, store, entry.guiSupplier().apply(playerRefComponent));
+        }
     }
 
 }

--- a/src/main/java/com/buuz135/adminui/util/PermissionList.java
+++ b/src/main/java/com/buuz135/adminui/util/PermissionList.java
@@ -11,12 +11,19 @@ public enum PermissionList {
     OPEN_UI("open", "ui", "You don't have permission to open admin menu"),
     //WARPS
     WARP_OPEN_UI("open", "warp", "You don't have permission to open warp menu"),
+    //MUTES
     MUTE_OPEN_UI("open", "mute", "You don't have permission to open mutes menu"),
+    //BANS
     BAN_OPEN_UI("open", "ban", "You don't have permission to open bans menu"),
+    //PLAYERS
     PLAYER_OPEN_UI("open", "player", "You don't have permission to open players menu"),
+    //ADMIN STICK
     ADMIN_STICK_OPEN_UI("open", "adminstick", "You don't have permission to open admin stick menu"),
+    //BACKUPS
     BACKUP_OPEN_UI("open", "backup", "You don't have permission to open backups menu"),
+    //STATS
     STATS_OPEN_UI("open", "stats", "You don't have permission to open server stats menu"),
+    //WHITELIST
     WHITELIST_OPEN_UI("open", "whitelist", "You don't have permission to open whitelist menu");
     private final String permission;
     private final String permissionRoot;

--- a/src/main/java/com/buuz135/adminui/util/PermissionList.java
+++ b/src/main/java/com/buuz135/adminui/util/PermissionList.java
@@ -19,6 +19,7 @@ public enum PermissionList {
     PLAYER_OPEN_UI("open", "player", "You don't have permission to open players menu"),
     //ADMIN STICK
     ADMIN_STICK_OPEN_UI("open", "adminstick", "You don't have permission to open admin stick menu"),
+    ADMIN_STICK_USE("use", "adminstick", "You don't have permission to use the admin stick"),
     //BACKUPS
     BACKUP_OPEN_UI("open", "backup", "You don't have permission to open backups menu"),
     //STATS

--- a/src/main/java/com/buuz135/adminui/util/PermissionList.java
+++ b/src/main/java/com/buuz135/adminui/util/PermissionList.java
@@ -1,0 +1,46 @@
+package com.buuz135.adminui.util;
+
+import com.hypixel.hytale.server.core.Message;
+import com.hypixel.hytale.server.core.entity.entities.Player;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum PermissionList {
+    //COMMANDS
+    OPEN_UI("open", "ui", "You don't have permission to open admin menu"),
+    //WARPS
+    WARP_OPEN_UI("open", "warp", "You don't have permission to open warp menu"),
+    MUTE_OPEN_UI("open", "mute", "You don't have permission to open mutes menu"),
+    BAN_OPEN_UI("open", "ban", "You don't have permission to open bans menu"),
+    PLAYER_OPEN_UI("open", "player", "You don't have permission to open players menu"),
+    ADMIN_STICK_OPEN_UI("open", "adminstick", "You don't have permission to open admin stick menu"),
+    BACKUP_OPEN_UI("open", "backup", "You don't have permission to open backups menu"),
+    STATS_OPEN_UI("open", "stats", "You don't have permission to open server stats menu"),
+    WHITELIST_OPEN_UI("open", "whitelist", "You don't have permission to open whitelist menu");
+    private final String permission;
+    private final String permissionRoot;
+    private final String denyMessage;
+
+    private PermissionList(String permission, String permissionRoot, String denyMessage){
+        this.permission = String.format("AdminUI.%s.%s", permissionRoot, permission);
+        this.permissionRoot = String.format("AdminUI.%s", permissionRoot);
+        this.denyMessage = denyMessage;
+    }
+
+    public Message getMessage(){
+        return Message.raw(denyMessage);
+    }
+
+    public String getPermission() {
+        return permission;
+    }
+
+    public String getPermissionRoot() {
+        return permissionRoot;
+    }
+
+    public Boolean hasPermission(Player player){
+        return player.hasPermission(this.getPermission()) || player.hasPermission(this.getPermissionRoot()) || player.hasPermission("AdminUI.admin");
+    }
+}


### PR DESCRIPTION
In this pull request, I added a permission system that allows pages to be hidden from user groups according to server permission groups.

## showcase:

### admin sees:

<img width="1889" height="989" alt="luckperms" src="https://github.com/user-attachments/assets/9ed6b6a8-1526-446d-9154-078e3c04e194" />
<img width="1262" height="720" alt="admin group" src="https://github.com/user-attachments/assets/0cdf2968-8afa-414f-aa3f-4cb8b7d6cdc5" />

### Server admin sees:
<img width="1880" height="974" alt="luckperms" src="https://github.com/user-attachments/assets/3ede669d-3c34-4f90-b7e9-5e24ce19b84c" />
<img width="1269" height="715" alt="server admin group" src="https://github.com/user-attachments/assets/1956012c-7e52-4e59-8e6a-86b2cd498a61" />

### default user sees:
<img width="1899" height="972" alt="изображение" src="https://github.com/user-attachments/assets/498d7187-3993-4636-a349-8dd5f3493d4a" />
<img width="1287" height="717" alt="изображение" src="https://github.com/user-attachments/assets/04cca614-a712-4261-b28b-c7af020bc839" />




